### PR TITLE
Added alpha parameter to better control base window width

### DIFF
--- a/s.py
+++ b/s.py
@@ -22,6 +22,7 @@ def sTransform( ts              : np.ndarray        ,
                 sample_rate     : Union[int, float] , 
                 frange          : Union[list]       = [0, 500]  , 
                 frate           : Union[int, float] = 1         , 
+                alpha           : int               = 1         ,
                 downsample      : Optional[int]     = None      
                 ) -> np.ndarray:
     
@@ -31,6 +32,7 @@ def sTransform( ts              : np.ndarray        ,
                 sample_rate         ts data sample rate
                 frange              frequency range (Hz)
                 frate               frequency sampling rate
+                alpha               window base width (base Gaussian dispersion)
                 downsample          down-sampled length in time
     Output:
                 amp                 spectrogram table
@@ -101,7 +103,7 @@ def sTransform( ts              : np.ndarray        ,
     for i in range(_scaled_frate, number_freq+1, _scaled_frate):                       
         amp[int(i/_scaled_frate)] = np.fft.ifft(
                     vec[Nfreq[0]+i:Nfreq[0]+i+downsampled_length]
-                    *_window_normal(downsampled_length, Nfreq[0]+i, 
+                    *_window_normal(downsampled_length, alpha+Nfreq[0]+i, 
                                     factor=1)*normalize_cut)
     
     return amp


### PR DESCRIPTION
### What it does:
This fix helps eliminate the artifacts at very low frequencies where the frequency window functions are too narrow.
### More explanation:
- added an argument `alpha=1` to `def sTransform()`.
- alpha is a baseline dispersion/deviation parameter that adds a fixed additional dilation to the frequency domain window function. Try different values to see the effect.
- alpha helps remove the artifacts due to the 'sharp cut-off' created by a narrow frequency Gaussian.
